### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://khalibloo.visualstudio.com/9cbefbc1-aeff-4e87-8731-700c6a33df71/55072ee4-978d-4753-9a55-53509364fe3f/_apis/work/boardbadge/2fb61c14-29e6-41b0-98d4-5fbdd4784ed1)](https://khalibloo.visualstudio.com/9cbefbc1-aeff-4e87-8731-700c6a33df71/_boards/board/t/55072ee4-978d-4753-9a55-53509364fe3f/Microsoft.RequirementCategory)
 # Alt Storefront for Saleor
 
 ## Getting Started


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://khalibloo.visualstudio.com/9cbefbc1-aeff-4e87-8731-700c6a33df71/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.