### PR TITLE
Workaround strange CircleCI error with browser installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ jobs:
       - node/install:
           node-version: 13.11.0
           install-yarn: true
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run: yarn test-e2e:no-build
 workflows:
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,12 @@ jobs:
     executor:
       name: node/default
     steps:
+      - browser-tools/install-browser-tools
       - attach_workspace:
           at: .
       - node/install:
           node-version: 13.11.0
           install-yarn: true
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - run: yarn test-e2e:no-build
 workflows:
   build-test-deploy:


### PR DESCRIPTION
Looks like installing the browsers before attaching the workspace fixes the browser installation errors.