### PR TITLE
Bring CI env closer to local testing env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           at: .
       - node/install:
           node-version: 13.11.0
-      - node/install-packages
+      - run: yarn
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - node/install:
           node-version: 13.11.0
           install-yarn: true
-      - run: yarn test-e2e
+      - run: yarn test-e2e:no-build
 workflows:
   build-test-deploy:
     jobs:
@@ -64,7 +64,7 @@ workflows:
             - install
       - test:
           requires:
-            - build
+            - install
       - test-e2e:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,21 +19,6 @@ jobs:
           root: .
           paths:
             - .
-  build:
-    executor:
-      name: node/default
-    steps:
-      - attach_workspace:
-          at: .
-      - node/install:
-          node-version: 13.11.0
-          install-yarn: true
-      - browser-tools/install-browser-tools
-      - run: yarn build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
   test:
     executor:
       name: node/default
@@ -54,20 +39,17 @@ jobs:
       - node/install:
           node-version: 13.11.0
           install-yarn: true
-      - run: yarn test-e2e:no-build
+      - run: yarn test-e2e
 workflows:
   build-test-deploy:
     jobs:
       - install
-      - build:
-          requires:
-            - install
       - test:
           requires:
             - install
       - test-e2e:
           requires:
-            - build
+            - install
       - heroku/deploy-via-git:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
           at: .
       - node/install:
           node-version: 13.11.0
+          install-yarn: true
       - run: yarn
       - persist_to_workspace:
           root: .

--- a/src/e2e/search.e2e.ts
+++ b/src/e2e/search.e2e.ts
@@ -52,7 +52,6 @@ test("shows search result items", async t => {
 
 test("shows filters column on default screen", async t => {
   await t
-    .takeScreenshot("./blah.png")
     .expect(page.filtersCol.visible)
     .ok()
     .expect(page.filtersBtn.exists)


### PR DESCRIPTION
- Use yarn for all jobs on CI
- Use build:ci instead of separate build job, to use the same define variables