### PR TITLE
refactor: move cookie notice to layout index

### DIFF
--- a/src/layouts/NavBar.tsx
+++ b/src/layouts/NavBar.tsx
@@ -9,7 +9,6 @@ import {
   Modal,
   Badge,
   Button,
-  Space,
 } from "antd";
 import { useIntl, Link, connect, ConnectRC, setLocale } from "umi";
 import {
@@ -22,7 +21,6 @@ import {
   LoginOutlined,
 } from "@ant-design/icons";
 import clx from "classnames";
-import lf from "localforage";
 
 import styles from "./NavBar.less";
 import ProductSearch from "@/components/ProductSearch";
@@ -36,8 +34,6 @@ import ResetPasswordRequestForm from "@/components/ResetPasswordRequestForm";
 import GuestForm from "@/components/GuestForm";
 import VSpacing from "@/components/VSpacing";
 import { CartCreateMutation_checkoutCreate_checkout } from "@/mutations/types/CartCreateMutation";
-import { getScreenSize } from "@/utils/utils";
-import config from "@/config";
 
 interface Props {
   authenticated: boolean;
@@ -53,11 +49,6 @@ const NavBar: ConnectRC<Props> = ({
   dispatch,
 }) => {
   const intl = useIntl();
-  const {
-    state: cookieDrawerOpen,
-    setTrue: openCookieDrawer,
-    setFalse: closeCookieDrawer,
-  } = useBoolean(false);
   const {
     state: searchDrawerOpen,
     setTrue: openSearchDrawer,
@@ -86,24 +77,6 @@ const NavBar: ConnectRC<Props> = ({
   useEffect(() => {
     refetch();
   }, [window.location.pathname]);
-  useEffect(() => {
-    if (config.altConfig.showCookieNotice) {
-      lf.getItem("accepted_cookie_notice").then(accepted => {
-        if (!accepted) {
-          openCookieDrawer();
-        }
-      });
-    }
-  }, []);
-  const screenSize = getScreenSize(responsive);
-  const cookieDrawerHeights = {
-    xs: 240,
-    sm: 200,
-    md: 180,
-    lg: 160,
-    xl: 160,
-    xxl: 160,
-  };
 
   const checkout = authenticated ? cartData?.me?.checkout : localCheckout;
 
@@ -234,50 +207,6 @@ const NavBar: ConnectRC<Props> = ({
           <GuestForm />
         </div>
       </Modal>
-      <Drawer
-        closable={false}
-        destroyOnClose
-        height={cookieDrawerHeights[screenSize]}
-        mask={false}
-        onClose={closeCookieDrawer}
-        placement="bottom"
-        visible={cookieDrawerOpen}
-      >
-        <Row justify="space-around" align="middle" className="full-height">
-          <Col span={16} xs={22} sm={22} md={20} lg={16}>
-            <Typography.Paragraph
-              className="center-text"
-              style={{ fontSize: "1.2rem" }}
-            >
-              {intl.formatMessage({ id: "cookies.notice" })}
-            </Typography.Paragraph>
-            <Row justify="center">
-              <Col>
-                <Space>
-                  <Link to="/pages/privacy">
-                    <Button size="large">
-                      {intl.formatMessage({ id: "cookies.privacyPolicy" })}
-                    </Button>
-                  </Link>
-                  <Button
-                    type="primary"
-                    size="large"
-                    onClick={() => {
-                      lf.setItem("accepted_cookie_notice", true).then(value => {
-                        if (value) {
-                          closeCookieDrawer();
-                        }
-                      });
-                    }}
-                  >
-                    {intl.formatMessage({ id: "cookies.accept" })}
-                  </Button>
-                </Space>
-              </Col>
-            </Row>
-          </Col>
-        </Row>
-      </Drawer>
       <Drawer
         visible={searchDrawerOpen}
         onClose={closeSearchDrawer}

--- a/src/layouts/index.less
+++ b/src/layouts/index.less
@@ -12,3 +12,13 @@
   display: flex;
   flex-direction: column;
 }
+
+.cookieNotice {
+  padding: 24px;
+  box-shadow: 0 -6px 16px -8px rgba(0, 0, 0, 0.08),
+    0 -9px 28px 0 rgba(0, 0, 0, 0.05), 0 -12px 48px 16px rgba(0, 0, 0, 0.03);
+}
+
+.cookieNoticeText {
+  font-size: 1.2rem;
+}

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Layout } from "antd";
+import { Affix, Button, Col, Layout, Row, Space, Typography } from "antd";
 import { Helmet } from "react-helmet";
 import clx from "classnames";
 
@@ -8,17 +8,34 @@ import NavBar from "./NavBar";
 import Footer from "./Footer";
 import { ApolloProvider } from "@apollo/client";
 import { client } from "@/apollo";
-import { connect, ConnectRC, Loading, useIntl } from "umi";
+import { connect, ConnectRC, Link, Loading, useIntl } from "umi";
 import { ConnectState } from "@/models/connect";
 import Loader from "@/components/Loader";
+import { useBoolean } from "@umijs/hooks";
+import lf from "localforage";
+import config from "@/config";
 
 interface Props {
   loading: Loading;
 }
 const BasicLayout: ConnectRC<Props> = ({ children, loading, dispatch }) => {
   const intl = useIntl();
+  const {
+    state: cookieDrawerOpen,
+    setTrue: openCookieDrawer,
+    setFalse: closeCookieDrawer,
+  } = useBoolean(false);
   useEffect(() => {
     dispatch?.({ type: "auth/initialize" });
+  }, []);
+  useEffect(() => {
+    if (config.altConfig.showCookieNotice) {
+      lf.getItem("accepted_cookie_notice").then(accepted => {
+        if (!accepted) {
+          openCookieDrawer();
+        }
+      });
+    }
   }, []);
   if (loading.effects["auth/initialize"]) {
     return <Loader />;
@@ -39,6 +56,49 @@ const BasicLayout: ConnectRC<Props> = ({ children, loading, dispatch }) => {
           </Layout.Footer>
         </Layout>
       </ApolloProvider>
+      {cookieDrawerOpen && (
+        <Affix offsetBottom={0} target={() => window}>
+          <Row
+            justify="space-around"
+            align="middle"
+            className={clx("full-height", "bg-default", styles.cookieNotice)}
+          >
+            <Col span={16} xs={22} sm={22} md={20} lg={16}>
+              <Typography.Paragraph
+                className={clx("center-text", styles.cookieNoticeText)}
+              >
+                {intl.formatMessage({ id: "cookies.notice" })}
+              </Typography.Paragraph>
+              <Row justify="center">
+                <Col>
+                  <Space>
+                    <Link to="/pages/privacy">
+                      <Button size="large">
+                        {intl.formatMessage({ id: "cookies.privacyPolicy" })}
+                      </Button>
+                    </Link>
+                    <Button
+                      type="primary"
+                      size="large"
+                      onClick={() => {
+                        lf.setItem("accepted_cookie_notice", true).then(
+                          value => {
+                            if (value) {
+                              closeCookieDrawer();
+                            }
+                          },
+                        );
+                      }}
+                    >
+                      {intl.formatMessage({ id: "cookies.accept" })}
+                    </Button>
+                  </Space>
+                </Col>
+              </Row>
+            </Col>
+          </Row>
+        </Affix>
+      )}
     </>
   );
 };

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -19,4 +19,7 @@ body {
   .ant-input-number-input-wrap > .ant-input-number-input {
     height: 100%;
   }
+  .bg-default {
+    background-color: @layout-body-background;
+  }
 }


### PR DESCRIPTION
Move cookie notice from NavBar to layout index, and use Affix instead of Drawer, so it can size itself to match its content.