### PR TITLE
fix: remove / at end of meilisearch url

### DIFF
--- a/src/components/ProductSearch.tsx
+++ b/src/components/ProductSearch.tsx
@@ -16,7 +16,7 @@ interface ProductDocument {
 let productsIndex: Index<ProductDocument>;
 if (config.meiliSearchUrl) {
   const client = new MeiliSearch({
-    host: config.meiliSearchUrl.href,
+    host: config.meiliSearchUrl.origin,
     apiKey: config.meiliSearchKey,
   });
   productsIndex = client.getIndex("products");


### PR DESCRIPTION
Meilisearch package fails to parse host URL correctly if it ends with /.