### PR TITLE
Revert "fix: rm / at end of meilisearch url"

### DIFF
--- a/src/components/ProductSearch.tsx
+++ b/src/components/ProductSearch.tsx
@@ -16,7 +16,7 @@ interface ProductDocument {
 let productsIndex: Index<ProductDocument>;
 if (config.meiliSearchUrl) {
   const client = new MeiliSearch({
-    host: config.meiliSearchUrl.origin,
+    host: config.meiliSearchUrl.href,
     apiKey: config.meiliSearchKey,
   });
   productsIndex = client.getIndex("products");


### PR DESCRIPTION
This reverts commit cf64fc8fdec43225776e514d4b29fe1e5479045f. Error was from hosted meilisearch server.